### PR TITLE
Feat: added visibility

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/visibility/VisibilityDemoAppStarter.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/visibility/VisibilityDemoAppStarter.java
@@ -1,0 +1,35 @@
+package com.dlsc.preferencesfx.demo.visibility;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+public class VisibilityDemoAppStarter extends Application {
+
+  public static void main(String[] args) {
+    launch(args);
+  }
+
+  @Override
+  public void start(Stage primaryStage) {
+    TabPane tabPane = new TabPane();
+    Pane[] panels = new Pane[] {new VisibilityNodeExample()};
+
+    for (Pane pane : panels) {
+      tabPane.getTabs().add(new Tab(pane.getClass().getSimpleName().replace("Visibility Example", ""), pane));
+    }
+
+    Scene mainScene = new Scene(tabPane);
+
+    primaryStage.setTitle("Visibility PreferencesFX Demo");
+    primaryStage.setScene(mainScene);
+    primaryStage.setWidth(1000);
+    primaryStage.setHeight(700);
+    primaryStage.show();
+    primaryStage.centerOnScreen();
+  }
+
+}

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/visibility/VisibilityNodeExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/visibility/VisibilityNodeExample.java
@@ -1,0 +1,61 @@
+package com.dlsc.preferencesfx.demo.visibility;
+
+import com.dlsc.preferencesfx.PreferencesFx;
+import com.dlsc.preferencesfx.model.Category;
+import com.dlsc.preferencesfx.model.Group;
+import com.dlsc.preferencesfx.model.Setting;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.scene.layout.StackPane;
+
+public class VisibilityNodeExample extends StackPane {
+
+  public PreferencesFx preferencesFx;
+
+  IntegerProperty brightness = new SimpleIntegerProperty(50);
+
+  IntegerProperty scale = new SimpleIntegerProperty(50);
+
+  IntegerProperty salary = new SimpleIntegerProperty(50);
+
+  IntegerProperty bonus = new SimpleIntegerProperty(50);
+
+  BooleanProperty nightMode = new SimpleBooleanProperty(true);
+
+  BooleanProperty productionVisibility = new SimpleBooleanProperty(true);
+
+  public VisibilityNodeExample() {
+    preferencesFx = createPreferences();
+    getChildren().add(new VisibilityNodeView(preferencesFx, this));
+  }
+
+  private PreferencesFx createPreferences() {
+    return PreferencesFx.of(VisibilityNodeExample.class,
+        Category.of("General",
+            Group.of("Display",
+                Setting.of("Brightness", brightness),
+                Setting.of("Night mode", nightMode, VisibilityProperty.of(brightness, (newValue) -> newValue.intValue() > 50)),
+                Setting.of("Scale", scale, VisibilityProperty.of(nightMode, (newValue) -> newValue)),
+                Setting.of("Is production category visible", productionVisibility)
+            )
+        ),
+        Category.of("Production", VisibilityProperty.of(productionVisibility, (newValue) -> newValue),
+            Group.of("Display",
+                Setting.of("Port", salary, VisibilityProperty.of(nightMode, (newValue) -> newValue))
+            )
+        ),
+        Category.of("View",
+            Group.of("Display",
+                Setting.of("Salary", salary, VisibilityProperty.of(nightMode, (newValue) -> newValue))
+            ),
+            Group.of("Bonuses",
+                VisibilityProperty.of(salary, (newValue) -> newValue.intValue() > 10),
+                Setting.of("Bonus", bonus)
+            )
+        )
+    ).persistWindowState(false).saveSettings(true).debugHistoryMode(false).buttonsVisibility(true);
+  }
+}

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/visibility/VisibilityNodeView.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/visibility/VisibilityNodeView.java
@@ -1,0 +1,92 @@
+package com.dlsc.preferencesfx.demo.visibility;
+
+import com.dlsc.preferencesfx.PreferencesFx;
+import com.dlsc.preferencesfx.demo.AppStarter;
+import com.dlsc.preferencesfx.view.PreferencesFxView;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+public class VisibilityNodeView extends VBox {
+  private PreferencesFx preferencesFx;
+  private VisibilityNodeExample rootPane;
+
+  private Label brightnessLabel;
+  private Label nightModeLabel;
+
+  public VisibilityNodeView(PreferencesFx preferencesFx, VisibilityNodeExample rootPane) {
+    this.preferencesFx = preferencesFx;
+    this.rootPane = rootPane;
+
+    initializeParts();
+    layoutParts();
+    setupBindings();
+    setupListeners();
+  }
+
+  private void initializeParts() {
+    brightnessLabel = new Label();
+    nightModeLabel = new Label();
+  }
+
+  private void layoutParts() {
+    // VBox with values
+    VBox valueBox = new VBox(
+            brightnessLabel,
+            nightModeLabel
+    );
+
+    valueBox.setSpacing(20);
+    valueBox.setPadding(new Insets(20, 0, 0, 20));
+    Button saveSettingsButton = new Button("Save Settings");
+    saveSettingsButton.setOnAction(event -> preferencesFx.saveSettings());
+    Button discardChangesButton = new Button("Discard Changes");
+    discardChangesButton.setOnAction(event -> preferencesFx.discardChanges());
+    // VBox with descriptions
+    VBox descriptionBox = new VBox(
+        new Label("Brightness:"),
+        new Label("Night mode:"),
+        saveSettingsButton,
+        discardChangesButton
+    );
+    descriptionBox.setSpacing(20);
+    descriptionBox.setPadding(new Insets(20, 0, 0, 20));
+
+    PreferencesFxView preferencesFxView = preferencesFx.getView();
+    // Put everything together
+    BorderPane pane = new BorderPane();
+    HBox hBox = new HBox(descriptionBox, valueBox);
+    pane.setLeft(hBox);
+    hBox.setPadding(new Insets(0, 20, 0, 0));
+    pane.setCenter(preferencesFxView);
+    VBox.setVgrow(pane, Priority.ALWAYS);
+    getChildren().addAll(
+        pane
+    );
+
+    // Styling
+    getStyleClass().add("demo-view");
+    if (rootPane.nightMode.get()) {
+      getStylesheets().add(AppStarter.class.getResource("darkTheme.css").toExternalForm());
+    }
+  }
+
+  private void setupBindings() {
+    brightnessLabel.textProperty().bind(rootPane.brightness.asString().concat("%"));
+    nightModeLabel.textProperty().bind(rootPane.nightMode.asString());
+  }
+
+  private void setupListeners() {
+    rootPane.nightMode.addListener((observable, oldValue, newValue) -> {
+      if (newValue) {
+        getStylesheets().add(AppStarter.class.getResource("darkTheme.css").toExternalForm());
+      } else {
+        getStylesheets().remove(AppStarter.class.getResource("darkTheme.css").toExternalForm());
+      }
+    });
+  }
+}

--- a/preferencesfx-demo/src/main/java/module-info.java
+++ b/preferencesfx-demo/src/main/java/module-info.java
@@ -8,4 +8,6 @@ module com.dlsc.preferencesfx.demo {
     exports com.dlsc.preferencesfx.demo;
 
     opens com.dlsc.preferencesfx.demo;
+    exports com.dlsc.preferencesfx.demo.visibility;
+    opens com.dlsc.preferencesfx.demo.visibility;
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/DoubleSliderControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/DoubleSliderControl.java
@@ -1,8 +1,10 @@
 package com.dlsc.preferencesfx.formsfx.view.controls;
 
 import com.dlsc.formsfx.model.structure.DoubleField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
@@ -29,6 +31,24 @@ public class DoubleSliderControl extends SimpleControl<DoubleField, HBox> {
   private double min;
   private double max;
   private int precision;
+
+  /**
+   * Constructs a DoubleSliderControl of {@link DoubleSliderControl} type, with visibility condition.
+   *
+   * @param min       minimum slider value
+   * @param max       maximum slider value
+   * @param precision number of digits after the decimal point
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed DoubleSliderControl
+   */
+  public static DoubleSliderControl of(double min, double max, int precision, VisibilityProperty visibilityProperty) {
+    DoubleSliderControl doubleSliderControl = new DoubleSliderControl(min, max, precision);
+
+    doubleSliderControl.visibilityProperty = visibilityProperty;
+
+    return doubleSliderControl;
+  }
 
   /**
    * Creates a slider for double values with a minimum and maximum value, with a set precision.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/IntegerSliderControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/IntegerSliderControl.java
@@ -1,6 +1,7 @@
 package com.dlsc.preferencesfx.formsfx.view.controls;
 
 import com.dlsc.formsfx.model.structure.IntegerField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
@@ -27,6 +28,23 @@ public class IntegerSliderControl extends SimpleControl<IntegerField, HBox> {
   private Label valueLabel;
   private int min;
   private int max;
+
+  /**
+   * Constructs a IntegerSliderControl of {@link IntegerSliderControl} type, with visibility condition.
+   *
+   * @param min minimum slider value
+   * @param max maximum slider value
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed IntegerSliderControl
+   */
+  public static IntegerSliderControl of(int min, int max, VisibilityProperty visibilityProperty) {
+    IntegerSliderControl integerSliderControl = new IntegerSliderControl(min, max);
+
+    integerSliderControl.visibilityProperty = visibilityProperty;
+
+    return integerSliderControl;
+  }
 
   /**
    * Creates a slider for integer values.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleBooleanControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleBooleanControl.java
@@ -21,6 +21,7 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.BooleanField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.scene.control.CheckBox;
 
 /**
@@ -34,6 +35,21 @@ import javafx.scene.control.CheckBox;
  */
 public class SimpleBooleanControl extends SimpleControl<BooleanField, CheckBox> {
 
+  /**
+   * Constructs a SimpleBooleanControl of {@link SimpleBooleanControl} type, with visibility condition.
+   *
+   * @param visibilityProperty - property for control visibility of this element
+   *
+   * @return the constructed SimpleBooleanControl
+   */
+  public static SimpleBooleanControl of(VisibilityProperty visibilityProperty) {
+    SimpleBooleanControl simpleBooleanControl = new SimpleBooleanControl();
+
+    simpleBooleanControl.visibilityProperty = visibilityProperty;
+
+    return simpleBooleanControl;
+  }
+  
   /**
    * {@inheritDoc}
    */

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleCheckBoxControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleCheckBoxControl.java
@@ -19,12 +19,14 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  * limitations under the License.
  * =========================LICENSE_END==================================
  */
-
-import com.dlsc.formsfx.model.structure.MultiSelectionField;
 import java.util.ArrayList;
 import java.util.List;
+
 import javafx.scene.control.CheckBox;
 import javafx.scene.layout.VBox;
+
+import com.dlsc.formsfx.model.structure.MultiSelectionField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 
 /**
  * This class provides the base implementation for a simple control to edit
@@ -42,6 +44,21 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
    * - The node is a VBox holding all node.
    */
   private final List<CheckBox> checkboxes = new ArrayList<>();
+
+  /**
+   * Constructs a SimpleCheckBoxControl of {@link SimpleCheckBoxControl} type, with visibility condition.
+   *
+   * @param visibilityProperty - property for control visibility of this element
+   *
+   * @return the constructed SimpleCheckBoxControl
+   */
+  public static <V> SimpleCheckBoxControl of(VisibilityProperty visibilityProperty) {
+    SimpleCheckBoxControl<V> simpleCheckBoxControl = new SimpleCheckBoxControl<>();
+
+    simpleCheckBoxControl.visibilityProperty = visibilityProperty;
+
+    return simpleCheckBoxControl;
+  }
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleChooserControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleChooserControl.java
@@ -19,10 +19,10 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  * =========================LICENSE_END==================================
  */
 
-import com.dlsc.formsfx.model.structure.StringField;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Pos;
 import javafx.scene.control.Button;
@@ -34,6 +34,9 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.StackPane;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
+
+import com.dlsc.formsfx.model.structure.StringField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 
 /**
  * This class provides the base implementation for a simple control to select or enter a directory
@@ -61,6 +64,24 @@ public class SimpleChooserControl extends SimpleControl<StringField, StackPane> 
   private String buttonText;
   private File initialDirectory;
   private boolean directory;
+
+  /**
+   * Constructs a SimpleChooserControl of {@link SimpleChooserControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleChooserControl
+   */
+  public static SimpleChooserControl of(String buttonText,
+                                        File initialDirectory,
+                                        boolean directory,
+                                        VisibilityProperty visibilityProperty) {
+    SimpleChooserControl simpleChooserControl = new SimpleChooserControl(buttonText, initialDirectory, directory);
+
+    simpleChooserControl.visibilityProperty = visibilityProperty;
+
+    return simpleChooserControl;
+  }
 
   /**
    * Create a new SimpleChooserControl.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleColorPickerControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleColorPickerControl.java
@@ -20,13 +20,16 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  * =========================LICENSE_END==================================
  */
 
-import com.dlsc.formsfx.model.structure.StringField;
 import java.util.Objects;
+
 import javafx.geometry.Pos;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
+
+import com.dlsc.formsfx.model.structure.StringField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 
 /**
  * This class provides the base implementation for a simple control to edit ColorPicker values.
@@ -54,6 +57,21 @@ public class SimpleColorPickerControl extends SimpleControl<StringField, StackPa
   public SimpleColorPickerControl(Color initialValue) {
     Objects.requireNonNull(initialValue);
     this.initialValue = initialValue;
+  }
+
+  /**
+   * Constructs a SimpleColorPickerControl of {@link SimpleColorPickerControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleColorPickerControl
+   */
+  public static SimpleColorPickerControl of(Color initialValue, VisibilityProperty visibilityProperty) {
+    SimpleColorPickerControl simpleColorPickerControl = new SimpleColorPickerControl(initialValue);
+
+    simpleColorPickerControl.visibilityProperty = visibilityProperty;
+
+    return simpleColorPickerControl;
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleComboBoxControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleComboBoxControl.java
@@ -20,11 +20,13 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  * =========================LICENSE_END==================================
  */
 
-import com.dlsc.formsfx.model.structure.SingleSelectionField;
 import javafx.geometry.Pos;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.layout.StackPane;
+
+import com.dlsc.formsfx.model.structure.SingleSelectionField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 
 /**
  * This class provides the base implementation for a simple control to edit
@@ -48,6 +50,21 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
   private Label fieldLabel;
   private ComboBox<V> comboBox;
   private Label readOnlyLabel;
+
+  /**
+   * Constructs a SimpleComboBoxControl of {@link SimpleComboBoxControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleComboBoxControl
+   */
+  public static SimpleComboBoxControl of(VisibilityProperty visibilityProperty) {
+    SimpleComboBoxControl simpleComboBoxControl = new SimpleComboBoxControl();
+
+    simpleComboBoxControl.visibilityProperty = visibilityProperty;
+
+    return simpleComboBoxControl;
+  }
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleControl.java
@@ -20,7 +20,6 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  * =========================LICENSE_END==================================
  */
 
-import com.dlsc.formsfx.model.structure.Field;
 import javafx.collections.ListChangeListener;
 import javafx.css.PseudoClass;
 import javafx.geometry.Point2D;
@@ -28,6 +27,9 @@ import javafx.scene.Node;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.Tooltip;
+
+import com.dlsc.formsfx.model.structure.Field;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 
 /**
  * This class provides a base for general purpose FormsFX controls.
@@ -59,6 +61,11 @@ public abstract class SimpleControl<F extends Field, N extends Node>
    * The control which gets rendered.
    */
   protected N node;
+
+  /**
+   * Property for control visibility.
+   */
+  protected VisibilityProperty visibilityProperty;
   /**
    * Tooltip to hold the error message.
    */
@@ -107,6 +114,14 @@ public abstract class SimpleControl<F extends Field, N extends Node>
     node.idProperty().bind(field.idProperty());
     node.disableProperty().bind(field.editableProperty().not());
     fieldLabel.textProperty().bind(field.labelProperty());
+
+    if (this.visibilityProperty != null) {
+      this.node.visibleProperty().bind(this.visibilityProperty.get());
+      this.node.managedProperty().bind(this.visibilityProperty.get());
+
+      this.getFieldLabel().visibleProperty().bind(this.visibilityProperty.get());
+      this.getFieldLabel().managedProperty().bind(this.visibilityProperty.get());
+    }
   }
 
   @Override
@@ -236,5 +251,13 @@ public abstract class SimpleControl<F extends Field, N extends Node>
 
   public N getNode() {
     return node;
+  }
+
+  public VisibilityProperty getVisibilityProperty() {
+    return this.visibilityProperty;
+  }
+
+  public void setVisibilityProperty(VisibilityProperty visibilityProperty) {
+    this.visibilityProperty = visibilityProperty;
   }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleDoubleControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleDoubleControl.java
@@ -21,6 +21,7 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.DoubleField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.scene.control.SpinnerValueFactory;
 
 /**
@@ -32,6 +33,21 @@ import javafx.scene.control.SpinnerValueFactory;
  * @author Marco Sanfratello
  */
 public class SimpleDoubleControl extends SimpleNumberControl<DoubleField, Double> {
+
+  /**
+   * Constructs a SimpleDoubleControl of {@link SimpleDoubleControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleDoubleControl
+   */
+  public static SimpleDoubleControl of(VisibilityProperty visibilityProperty) {
+    SimpleDoubleControl simpleDoubleControl = new SimpleDoubleControl();
+
+    simpleDoubleControl.visibilityProperty = visibilityProperty;
+
+    return simpleDoubleControl;
+  }
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleIntegerControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleIntegerControl.java
@@ -21,6 +21,7 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.IntegerField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -36,6 +37,21 @@ import javafx.util.converter.IntegerStringConverter;
  * @author Marco Sanfratello
  */
 public class SimpleIntegerControl extends SimpleNumberControl<IntegerField, Integer> {
+
+  /**
+   * Constructs a SimpleIntegerControl of {@link SimpleIntegerControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleIntegerControl
+   */
+  public static SimpleIntegerControl of(VisibilityProperty visibilityProperty) {
+    SimpleIntegerControl simpleIntegerControl = new SimpleIntegerControl();
+
+    simpleIntegerControl.visibilityProperty = visibilityProperty;
+
+    return simpleIntegerControl;
+  }
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleListViewControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleListViewControl.java
@@ -21,6 +21,7 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.MultiSelectionField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.collections.ListChangeListener;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
@@ -49,6 +50,22 @@ public class SimpleListViewControl<V>
    * The flag used for setting the selection properly.
    */
   private boolean preventUpdate;
+
+  /**
+   * Constructs a SimpleListViewControl of {@link SimpleListViewControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleListViewControl
+   */
+  public static SimpleListViewControl of(VisibilityProperty visibilityProperty) {
+    SimpleListViewControl simpleListViewControl = new SimpleListViewControl();
+
+    simpleListViewControl.visibilityProperty = visibilityProperty;
+
+    return simpleListViewControl;
+  }
+
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimplePasswordControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimplePasswordControl.java
@@ -21,6 +21,7 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.PasswordField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringBinding;
 import javafx.geometry.Pos;
@@ -54,6 +55,21 @@ public class SimplePasswordControl extends SimpleControl<PasswordField, StackPan
      * Translates characters found in user input into '*'
      */
     protected StringBinding obfuscatedUserInputBinding;
+
+    /**
+     * Constructs a SimplePasswordControl of {@link SimplePasswordControl} type, with visibility condition.
+     *
+     * @param visibilityProperty property for control visibility of this element
+     *
+     * @return the constructed SimplePasswordControl
+     */
+    public static SimplePasswordControl of(VisibilityProperty visibilityProperty) {
+        SimplePasswordControl simplePasswordControl = new SimplePasswordControl();
+
+        simplePasswordControl.visibilityProperty = visibilityProperty;
+
+        return simplePasswordControl;
+    }
 
     /**
      * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleRadioButtonControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleRadioButtonControl.java
@@ -21,8 +21,11 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.SingleSelectionField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import java.util.ArrayList;
 import java.util.List;
+
+import javafx.scene.control.Label;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.layout.VBox;
@@ -45,6 +48,23 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
    */
   private final List<RadioButton> radioButtons = new ArrayList<>();
   private ToggleGroup toggleGroup;
+
+  private Label fieldLabel;
+
+  /**
+   * Constructs a SimpleRadioButtonControl of {@link SimpleRadioButtonControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleRadioButtonControl
+   */
+  public static SimpleRadioButtonControl of(VisibilityProperty visibilityProperty) {
+    SimpleRadioButtonControl simpleRadioButtonControl = new SimpleRadioButtonControl();
+
+    simpleRadioButtonControl.visibilityProperty = visibilityProperty;
+
+    return simpleRadioButtonControl;
+  }
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleTextControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleTextControl.java
@@ -21,6 +21,7 @@ package com.dlsc.preferencesfx.formsfx.view.controls;
  */
 
 import com.dlsc.formsfx.model.structure.StringField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.beans.binding.Bindings;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
@@ -49,6 +50,21 @@ public class SimpleTextControl extends SimpleControl<StringField, StackPane> {
   private TextArea editableArea;
   private Label readOnlyLabel;
   private Label fieldLabel;
+
+  /**
+   * Constructs a SimpleTextControl of {@link SimpleTextControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed SimpleTextControl
+   */
+  public static SimpleTextControl of(VisibilityProperty visibilityProperty) {
+    SimpleTextControl simpleTextControl = new SimpleTextControl();
+
+    simpleTextControl.visibilityProperty = visibilityProperty;
+
+    return simpleTextControl;
+  }
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/ToggleControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/ToggleControl.java
@@ -1,6 +1,7 @@
 package com.dlsc.preferencesfx.formsfx.view.controls;
 
 import com.dlsc.formsfx.model.structure.BooleanField;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.scene.control.Label;
 import org.controlsfx.control.ToggleSwitch;
 
@@ -19,6 +20,21 @@ public class ToggleControl extends SimpleControl<BooleanField, ToggleSwitch> {
    * - container holds the toggle so that it can be styled properly.
    */
   private Label fieldLabel;
+
+  /**
+   * Constructs a ToggleControl of {@link ToggleControl} type, with visibility condition.
+   *
+   * @param visibilityProperty property for control visibility of this element
+   *
+   * @return the constructed ToggleControl
+   */
+  public static ToggleControl of(VisibilityProperty visibilityProperty) {
+    ToggleControl toggleControl = new ToggleControl();
+
+    toggleControl.visibilityProperty = visibilityProperty;
+
+    return toggleControl;
+  }
 
   /**
    * {@inheritDoc}
@@ -74,5 +90,3 @@ public class ToggleControl extends SimpleControl<BooleanField, ToggleSwitch> {
   }
 
 }
-
-

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxFormRenderer.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxFormRenderer.java
@@ -47,7 +47,7 @@ public class PreferencesFxFormRenderer extends GridPane implements ViewMixin {
   @Override
   public void initializeParts() {
     groups = form.getGroups().stream().map(
-        g -> new PreferencesFxGroupRenderer((PreferencesFxGroup) g, this)
+        group -> new PreferencesFxGroupRenderer((PreferencesFxGroup) group, this)
     ).collect(Collectors.toList());
   }
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroup.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroup.java
@@ -24,6 +24,7 @@ import com.dlsc.formsfx.model.structure.Element;
 import com.dlsc.formsfx.model.structure.Group;
 import com.dlsc.formsfx.model.util.TranslationService;
 import com.dlsc.preferencesfx.util.Strings;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 
@@ -48,6 +49,8 @@ public class PreferencesFxGroup extends Group {
   private final StringProperty title = new SimpleStringProperty("");
 
   private PreferencesFxGroupRenderer renderer;
+
+  private VisibilityProperty visibilityProperty;
 
   /**
    * {@inheritDoc}
@@ -84,6 +87,11 @@ public class PreferencesFxGroup extends Group {
     return this;
   }
 
+  public PreferencesFxGroup visibilityProperty(VisibilityProperty visibilityProperty) {
+    this.visibilityProperty = visibilityProperty;
+    return this;
+  }
+
   public String getTitle() {
     return title.get();
   }
@@ -115,5 +123,13 @@ public class PreferencesFxGroup extends Group {
     if (!Strings.isNullOrEmpty(titleKey.getValue())) {
       title.setValue(translationService.translate(titleKey.get()));
     }
+  }
+
+  public VisibilityProperty getVisibilityProperty() {
+    return visibilityProperty;
+  }
+
+  public void setVisibilityProperty(VisibilityProperty visibilityProperty) {
+    this.visibilityProperty = visibilityProperty;
   }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroupRenderer.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroupRenderer.java
@@ -5,6 +5,7 @@ import com.dlsc.formsfx.model.structure.Field;
 import com.dlsc.formsfx.model.structure.NodeElement;
 import com.dlsc.preferencesfx.formsfx.view.controls.SimpleControl;
 import com.dlsc.preferencesfx.util.PreferencesFxUtils;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import java.util.List;
 import java.util.stream.Collectors;
 import javafx.geometry.Insets;
@@ -125,6 +126,13 @@ public class PreferencesFxGroupRenderer {
    */
   public void setupBindings() {
     titleLabel.textProperty().bind(preferencesGroup.titleProperty());
+
+    VisibilityProperty visibilityProperty = preferencesGroup.getVisibilityProperty();
+
+    if (visibilityProperty != null) {
+      this.titleLabel.visibleProperty().bind(visibilityProperty.get());
+      this.titleLabel.managedProperty().bind(visibilityProperty.get());
+    }
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Category.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Category.java
@@ -5,6 +5,7 @@ import static com.dlsc.preferencesfx.util.Constants.BREADCRUMB_DELIMITER;
 import com.dlsc.formsfx.model.util.TranslationService;
 import com.dlsc.preferencesfx.util.PreferencesFxUtils;
 import com.dlsc.preferencesfx.util.Strings;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import com.dlsc.preferencesfx.view.CategoryView;
 import java.util.Arrays;
 import java.util.List;
@@ -35,29 +36,33 @@ public class Category {
   private Node itemIcon;
   private boolean expand = false;
 
+  private VisibilityProperty visibilityProperty;
+
   /**
    * Creates a category without groups, for top-level categories without any settings.
    *
    * @param description Category name, for display in {@link CategoryView}
    */
-  private Category(String description) {
+  private Category(String description, VisibilityProperty visibilityProperty) {
+    this.visibilityProperty = visibilityProperty;
+
     descriptionKey.setValue(description);
     translate(null);
     setBreadcrumb(description);
   }
 
-  private Category(String description, Group... groups) {
-    this(description);
+  private Category(String description, VisibilityProperty visibilityProperty, Group... groups) {
+    this(description, visibilityProperty);
     this.groups = Arrays.asList(groups);
   }
 
-  private Category(String description, Node itemIcon) {
-    this(description);
+  private Category(String description, Node itemIcon, VisibilityProperty visibilityProperty) {
+    this(description, visibilityProperty);
     this.itemIcon = itemIcon;
   }
 
-  private Category(String description, Node itemIcon, Group... groups) {
-    this(description, groups);
+  private Category(String description, Node itemIcon, VisibilityProperty visibilityProperty, Group... groups) {
+    this(description, visibilityProperty, groups);
     this.itemIcon = itemIcon;
   }
 
@@ -69,7 +74,19 @@ public class Category {
    * @return initialized Category object
    */
   public static Category of(String description) {
-    return new Category(description);
+    return new Category(description, null);
+  }
+
+  /**
+   * Creates an empty category.
+   * Can be used for top-level categories without {@link Setting}.
+   *
+   * @param description Category name, for display in {@link CategoryView}
+   * @param visibilityProperty control category visibility
+   * @return initialized Category object
+   */
+  public static Category of(String description, VisibilityProperty visibilityProperty) {
+    return new Category(description, visibilityProperty);
   }
 
   /**
@@ -80,7 +97,19 @@ public class Category {
    * @return initialized Category object
    */
   public static Category of(String description, Group... groups) {
-    return new Category(description, groups);
+    return new Category(description, null, groups);
+  }
+
+  /**
+   * Creates a new category from groups.
+   *
+   * @param description Category name, for display in {@link CategoryView}
+   * @param groups      {@link Group} with {@link Setting} to be shown in the {@link CategoryView}
+   * @param visibilityProperty control category visibility
+   * @return initialized Category object
+   */
+  public static Category of(String description, VisibilityProperty visibilityProperty, Group... groups) {
+    return new Category(description, visibilityProperty, groups);
   }
 
   /**
@@ -91,7 +120,19 @@ public class Category {
    * @return initialized Category object
    */
   public static Category of(String description, Setting... settings) {
-    return new Category(description, Group.of(settings));
+    return new Category(description, null, Group.of(settings));
+  }
+
+  /**
+   * Creates a new category from settings, if the settings shouldn't be individually grouped.
+   *
+   * @param description Category name, for display in {@link CategoryView}
+   * @param settings    {@link Setting} to be shown in the {@link CategoryView}
+   * @param visibilityProperty control category visibility
+   * @return initialized Category object
+   */
+  public static Category of(String description, VisibilityProperty visibilityProperty, Setting... settings) {
+    return new Category(description, visibilityProperty, Group.of(settings));
   }
 
   /**
@@ -103,7 +144,20 @@ public class Category {
    * @return initialized Category object
    */
   public static Category of(String description, Node itemIcon) {
-    return new Category(description, itemIcon);
+    return new Category(description, itemIcon, null);
+  }
+
+  /**
+   * Creates an empty category.
+   * Can be used for top-level categories without {@link Setting}.
+   *
+   * @param description Category name, for display in {@link CategoryView}
+   * @param itemIcon    Icon to be shown next to the category name
+   * @param visibilityProperty control category visibility
+   * @return initialized Category object
+   */
+  public static Category of(String description, Node itemIcon, VisibilityProperty visibilityProperty) {
+    return new Category(description, itemIcon, visibilityProperty);
   }
 
   /**
@@ -115,7 +169,20 @@ public class Category {
    * @return initialized Category object
    */
   public static Category of(String description, Node itemIcon, Group... groups) {
-    return new Category(description, itemIcon, groups);
+    return new Category(description, itemIcon, null, groups);
+  }
+
+  /**
+   * Creates a new category from groups.
+   *
+   * @param description Category name, for display in {@link CategoryView}
+   * @param itemIcon    Icon to be shown next to the category name
+   * @param groups      {@link Group} with {@link Setting} to be shown in the {@link CategoryView}
+   * @param visibilityProperty control category visibility
+   * @return initialized Category object
+   */
+  public static Category of(String description, Node itemIcon, VisibilityProperty visibilityProperty, Group... groups) {
+    return new Category(description, itemIcon, visibilityProperty, groups);
   }
 
   /**
@@ -127,7 +194,20 @@ public class Category {
    * @return initialized Category object
    */
   public static Category of(String description, Node itemIcon, Setting... settings) {
-    return new Category(description, itemIcon, Group.of(settings));
+    return new Category(description, itemIcon, null, Group.of(settings));
+  }
+
+  /**
+   * Creates a new category from settings, if the settings shouldn't be individually grouped.
+   *
+   * @param description Category name, for display in {@link CategoryView}
+   * @param itemIcon    Icon to be shown next to the category name
+   * @param settings    {@link Setting} to be shown in the {@link CategoryView}
+   * @param visibilityProperty control category visibility
+   * @return initialized Category object
+   */
+  public static Category of(String description, Node itemIcon, VisibilityProperty visibilityProperty, Setting... settings) {
+    return new Category(description, itemIcon, visibilityProperty, Group.of(settings));
   }
 
   /**
@@ -274,5 +354,13 @@ public class Category {
    */
   public boolean isExpand() {
     return expand;
+  }
+
+  public VisibilityProperty visibilityProperty() {
+    return visibilityProperty;
+  }
+
+  public void setVisibilityProperty(VisibilityProperty visibilityProperty) {
+    this.visibilityProperty = visibilityProperty;
   }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Group.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Group.java
@@ -1,7 +1,11 @@
 package com.dlsc.preferencesfx.model;
 
+import com.dlsc.formsfx.model.structure.DataField;
+import com.dlsc.formsfx.model.structure.Element;
+import com.dlsc.preferencesfx.formsfx.view.controls.SimpleControl;
 import com.dlsc.preferencesfx.formsfx.view.renderer.PreferencesFxGroup;
 import com.dlsc.preferencesfx.util.Constants;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import java.util.Arrays;
 import java.util.List;
 import javafx.beans.property.SimpleStringProperty;
@@ -30,9 +34,12 @@ public class Group {
   private final EventHandler<MouseEvent> unmarker = event -> unmark();
   private final StringProperty breadcrumb = new SimpleStringProperty("");
 
-  private Group(String description, Setting... settings) {
+  private VisibilityProperty visibilityProperty;
+
+  private Group(String description, VisibilityProperty visibilityProperty, Setting... settings) {
     this.description = description;
     this.settings = Arrays.asList(settings);
+    this.visibilityProperty = visibilityProperty;
   }
 
   /**
@@ -43,7 +50,15 @@ public class Group {
    * @return this object for chaining with the fluent API
    */
   public static Group of(String description, Setting... settings) {
-    return new Group(description, settings);
+    return new Group(description, null, settings);
+  }
+
+  public static Group of(String description, VisibilityProperty visibilityProperty, Setting... settings) {
+    Group group = new Group(description, visibilityProperty, settings);
+
+    group.applyVisibilityForSettings();
+
+    return group;
   }
 
   /**
@@ -53,7 +68,22 @@ public class Group {
    * @return this object for chaining with the fluent API
    */
   public static Group of(Setting... settings) {
-    return new Group(null, settings);
+    return new Group(null, null, settings);
+  }
+
+  /**
+   * Constructs a new group with {@code settings}, without a {@code description}.
+   *
+   * @param settings the settings that belong to this group
+   * @param visibilityProperty visibility condition for Group
+   * @return this object for chaining with the fluent API
+   */
+  public static Group of(VisibilityProperty visibilityProperty, Setting... settings) {
+    Group group = new Group(null, visibilityProperty, settings);
+
+    group.applyVisibilityForSettings();
+
+    return group;
   }
 
   /**
@@ -142,5 +172,21 @@ public class Group {
 
   public void setBreadcrumb(String breadcrumb) {
     this.breadcrumb.set(breadcrumb);
+  }
+
+  public VisibilityProperty getVisibilityProperty() {
+    return visibilityProperty;
+  }
+
+  public void setVisibilityProperty(VisibilityProperty visibilityProperty) {
+    this.visibilityProperty = visibilityProperty;
+  }
+
+  private void applyVisibilityForSettings() {
+    if (settings != null) {
+      for (Setting setting : settings) {
+        setting.applyVisibility(visibilityProperty);
+      }
+    }
   }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
@@ -17,6 +17,7 @@ import com.dlsc.preferencesfx.formsfx.view.controls.SimpleListViewControl;
 import com.dlsc.preferencesfx.formsfx.view.controls.SimpleTextControl;
 import com.dlsc.preferencesfx.formsfx.view.controls.ToggleControl;
 import com.dlsc.preferencesfx.util.Constants;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import com.dlsc.preferencesfx.util.StorageHandler;
 import java.io.File;
 import java.util.Objects;
@@ -73,12 +74,16 @@ public class Setting<E extends Element, P extends Property> {
    * @return the constructed setting
    */
   public static Setting of(String description, BooleanProperty property) {
+    return of(description, property, null);
+  }
+
+  public static Setting of(String description, BooleanProperty property, VisibilityProperty visibilityProperty) {
     return new Setting<>(
-        description,
-        Field.ofBooleanType(property)
-            .label(description)
-            .render(new ToggleControl()),
-        property
+            description,
+            Field.ofBooleanType(property)
+                    .label(description)
+                    .render(ToggleControl.of(visibilityProperty)),
+            property
     );
   }
 
@@ -90,27 +95,51 @@ public class Setting<E extends Element, P extends Property> {
    * @return the constructed setting
    */
   public static Setting of(String description, IntegerProperty property) {
+    return of(description, property, null);
+  }
+
+  /**
+   * Constructs a setting of {@link Integer} type, which is represented by a {@link TextField}.
+   *
+   * @param description the title of this setting
+   * @param property    to be bound, saved / loaded and used for undo / redo
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static Setting of(String description, IntegerProperty property, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofIntegerType(property)
             .label(description)
-            .render(new SimpleIntegerControl()),
+            .render(SimpleIntegerControl.of(visibilityProperty)),
         property);
   }
+
+    /**
+     * Constructs a setting of {@link Double} type, which is represented by a {@link TextField}.
+     *
+     * @param description the title of this setting
+     * @param property    to be bound, saved / loaded and used for undo / redo
+     * @return the constructed setting
+     */
+    public static Setting of(String description, DoubleProperty property) {
+        return of(description, property, null);
+    }
 
   /**
    * Constructs a setting of {@link Double} type, which is represented by a {@link TextField}.
    *
    * @param description the title of this setting
    * @param property    to be bound, saved / loaded and used for undo / redo
+   * @param visibilityProperty control visibility of element
    * @return the constructed setting
    */
-  public static Setting of(String description, DoubleProperty property) {
+  public static Setting of(String description, DoubleProperty property, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofDoubleType(property)
             .label(description)
-            .render(new SimpleDoubleControl()),
+            .render(SimpleDoubleControl.of(visibilityProperty)),
         property);
   }
 
@@ -126,11 +155,26 @@ public class Setting<E extends Element, P extends Property> {
    */
   public static Setting of(
       String description, DoubleProperty property, double min, double max, int precision) {
+      return of(description, property, null);
+  }
+  /**
+   * Constructs a setting of {@link Double} type, which is represented by a {@link Slider}.
+   *
+   * @param description the title of this setting
+   * @param property    to be bound, saved / loaded and used for undo / redo
+   * @param min         minimum value of the {@link Slider}
+   * @param max         maximum value of the {@link Slider}
+   * @param precision   number of digits after the decimal point
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static Setting of(
+      String description, DoubleProperty property, double min, double max, int precision, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofDoubleType(property)
             .label(description)
-            .render(new DoubleSliderControl(min, max, precision)),
+            .render(DoubleSliderControl.of(min, max, precision, visibilityProperty)),
         property);
   }
 
@@ -144,11 +188,24 @@ public class Setting<E extends Element, P extends Property> {
    * @return the constructed setting
    */
   public static Setting of(String description, IntegerProperty property, int min, int max) {
+      return of(description, property, null);
+  }
+  /**
+   * Constructs a setting of {@link Integer} type, which is represented by a {@link Slider}.
+   *
+   * @param description the title of this setting
+   * @param property    to be bound, saved / loaded and used for undo / redo
+   * @param min         minimum value of the {@link Slider}
+   * @param max         maximum value of the {@link Slider}
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static Setting of(String description, IntegerProperty property, int min, int max, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofIntegerType(property)
             .label(description)
-            .render(new IntegerSliderControl(min, max)),
+            .render(IntegerSliderControl.of(min, max, visibilityProperty)),
         property);
   }
 
@@ -160,11 +217,23 @@ public class Setting<E extends Element, P extends Property> {
    * @return the constructed setting
    */
   public static Setting of(String description, StringProperty property) {
+      return of(description, property, null);
+  }
+
+  /**
+   * Constructs a setting of {@link String} type, which is represented by a {@link TextField}.
+   *
+   * @param description the title of this setting
+   * @param property    to be bound, saved / loaded and used for undo / redo
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static Setting of(String description, StringProperty property, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofStringType(property)
             .label(description)
-            .render(new SimpleTextControl()),
+            .render(SimpleTextControl.of(visibilityProperty)),
         property);
   }
 
@@ -181,11 +250,28 @@ public class Setting<E extends Element, P extends Property> {
    */
   public static <P> Setting of(
       String description, ListProperty<P> items, ObjectProperty<P> selection) {
+      return of(description, items, selection, null);
+  }
+
+  /**
+   * Creates a combobox with single selection.
+   *
+   * @param description the title of this setting
+   * @param items       the items which are possible to choose in the combobox, which are shown
+   *                    in their {@link #toString()} representation
+   * @param selection   the currently selected item of the combobox to be bound, saved / loaded and
+   *                    used for undo / redo
+   * @param <P>         the type of objects which should be displayed in the combobox
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static <P> Setting of(
+      String description, ListProperty<P> items, ObjectProperty<P> selection, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofSingleSelectionType(items, selection)
             .label(description)
-            .render(new SimpleComboBoxControl<>()),
+            .render(SimpleComboBoxControl.of(visibilityProperty)),
         selection);
   }
 
@@ -202,11 +288,28 @@ public class Setting<E extends Element, P extends Property> {
    */
   public static <P> Setting of(
       String description, ObservableList<P> items, ObjectProperty<P> selection) {
+      return of(description, items, selection, null);
+  }
+
+  /**
+   * Creates a combobox with single selection.
+   *
+   * @param description the title of this setting
+   * @param items       the items which are possible to choose in the combobox, which are shown
+   *                    in their {@link #toString()} representation
+   * @param selection   the currently selected item of the combobox to be bound, saved / loaded and
+   *                    used for undo / redo
+   * @param <P>         the type of objects which should be displayed in the combobox
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static <P> Setting of(
+      String description, ObservableList<P> items, ObjectProperty<P> selection, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofSingleSelectionType(new SimpleListProperty<>(items), selection)
             .label(description)
-            .render(new SimpleComboBoxControl<>()),
+            .render(SimpleComboBoxControl.of(visibilityProperty)),
         selection);
   }
 
@@ -224,11 +327,29 @@ public class Setting<E extends Element, P extends Property> {
    */
   public static <P> Setting of(
       String description, ListProperty<P> items, ListProperty<P> selections) {
+      return of(description, items, selections, null);
+  }
+
+  /**
+   * Creates a combobox with multiselection.
+   * At least one element has to be selected at all times.
+   *
+   * @param description the title of this setting
+   * @param items       the items which are possible to choose in the combobox, which are shown
+   *                    in their {@link #toString()} representation
+   * @param selections  the currently selected item(s) of the combobox to be bound, saved / loaded
+   *                    and used for undo / redo
+   * @param <P>         the type of objects which should be displayed in the combobox
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static <P> Setting of(
+      String description, ListProperty<P> items, ListProperty<P> selections, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofMultiSelectionType(items, selections)
             .label(description)
-            .render(new SimpleListViewControl<>()),
+            .render(SimpleListViewControl.of(visibilityProperty)),
         selections);
   }
 
@@ -246,11 +367,29 @@ public class Setting<E extends Element, P extends Property> {
    */
   public static <P> Setting of(
       String description, ObservableList<P> items, ListProperty<P> selections) {
+      return of(description, items, selections, null);
+  }
+
+  /**
+   * Creates a combobox with multiselection.
+   * At least one element has to be selected at all times.
+   *
+   * @param description the title of this setting
+   * @param items       the items which are possible to choose in the combobox, which are shown
+   *                    in their {@link #toString()} representation
+   * @param selections  the currently selected item(s) of the combobox to be bound, saved / loaded
+   *                    and used for undo / redo
+   * @param <P>         the type of objects which should be displayed in the combobox
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static <P> Setting of(
+      String description, ObservableList<P> items, ListProperty<P> selections, VisibilityProperty visibilityProperty) {
     return new Setting<>(
         description,
         Field.ofMultiSelectionType(new SimpleListProperty<>(items), selections)
             .label(description)
-            .render(new SimpleListViewControl<>()),
+            .render(SimpleListViewControl.of(visibilityProperty)),
         selections);
   }
 
@@ -298,6 +437,18 @@ public class Setting<E extends Element, P extends Property> {
    * @return the constructed setting
    */
   public static Setting of(String description, ObjectProperty<Color> colorProperty) {
+      return of(description, colorProperty, null);
+  }
+
+  /**
+   * Creates a custom color picker control.
+   *
+   * @param description   the title of this setting
+   * @param colorProperty the current selected color value
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static Setting of(String description, ObjectProperty<Color> colorProperty, VisibilityProperty visibilityProperty) {
     StringProperty stringProperty = new SimpleStringProperty();
     stringProperty.bindBidirectional(
         colorProperty, new StringConverter<Color>() {
@@ -317,8 +468,8 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofStringType(stringProperty)
             .label(description)
-            .render(new SimpleColorPickerControl(
-                Objects.isNull(colorProperty.get()) ? Color.BLACK : colorProperty.get())
+            .render(SimpleColorPickerControl.of(
+                Objects.isNull(colorProperty.get()) ? Color.BLACK : colorProperty.get(), visibilityProperty)
             ),
         stringProperty
     );
@@ -371,6 +522,27 @@ public class Setting<E extends Element, P extends Property> {
                            String buttonText,
                            File initialDirectory,
                            boolean directory) {
+    return of(description, fileProperty, buttonText, initialDirectory, directory, null);
+  }
+
+  /**
+   * Creates a file/directory chooser control.
+   *
+   * @param description       the title of this setting
+   * @param fileProperty      the property to which the chosen file / directory should be set to
+   * @param buttonText        text of the button to open the file / directory chooser
+   * @param initialDirectory  An optional initial path, can be null. If null, will use the path from
+   *                          the previously chosen file if present.
+   * @param directory         true, if only directories are allowed
+   * @param visibilityProperty control visibility of element
+   * @return the constructed setting
+   */
+  public static Setting of(String description,
+                           ObjectProperty<File> fileProperty,
+                           String buttonText,
+                           File initialDirectory,
+                           boolean directory,
+      VisibilityProperty visibilityProperty) {
     StringProperty stringProperty = new SimpleStringProperty();
     stringProperty.bindBidirectional(
         fileProperty, new StringConverter<File>() {
@@ -393,7 +565,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofStringType(stringProperty)
             .label(description)
-            .render(new SimpleChooserControl(buttonText, initialDirectory, directory)
+            .render(SimpleChooserControl.of(buttonText, initialDirectory, directory, visibilityProperty)
             ),
         stringProperty
     );
@@ -598,5 +770,16 @@ public class Setting<E extends Element, P extends Property> {
   public Setting customKey(String key) {
     this.key = key;
     return this;
+  }
+
+  /**
+   * Apply {@link VisibilityProperty} to renderer ({@link SimpleControl}.
+   *
+   * @param visibilityProperty source visibility condition
+   */
+  public void applyVisibility(VisibilityProperty visibilityProperty) {
+    SimpleControl renderer = (SimpleControl) ((Field) getElement()).getRenderer();
+
+    renderer.setVisibilityProperty(visibilityProperty);
   }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/VisibilityProperty.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/VisibilityProperty.java
@@ -1,0 +1,21 @@
+package com.dlsc.preferencesfx.util;
+
+import java.util.function.Function;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
+
+@FunctionalInterface
+public interface VisibilityProperty {
+    BooleanProperty get();
+
+    static <T> VisibilityProperty of(Property<T> property, Function<T, Boolean> visibilityFunc) {
+        return () -> {
+            BooleanProperty visibilityProperty = new SimpleBooleanProperty(true);
+
+            property.addListener((observable, oldValue, newValue) -> visibilityProperty.set(visibilityFunc.apply(newValue)));
+
+            return visibilityProperty;
+        };
+    }
+}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryController.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryController.java
@@ -3,6 +3,7 @@ package com.dlsc.preferencesfx.view;
 import static com.dlsc.preferencesfx.util.Constants.SCROLLBAR_SUBTRACT;
 
 import com.dlsc.preferencesfx.model.Category;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import java.util.HashMap;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryPresenter.java
@@ -104,12 +104,16 @@ public class CategoryPresenter implements Presenter {
 
     // create PreferenceGroups from Groups
     for (int i = 0; i < groups.size(); i++) {
-      PreferencesFxGroup preferencesGroup =
-          (PreferencesFxGroup) PreferencesFxGroup.of().title(groups.get(i).getDescription());
-      groups.get(i).setPreferencesGroup(preferencesGroup);
+      Group group = groups.get(i);
+      PreferencesFxGroup preferencesGroup = (PreferencesFxGroup) PreferencesFxGroup
+          .of()
+          .visibilityProperty(group.getVisibilityProperty())
+          .title(group.getDescription());
+      group.setPreferencesGroup(preferencesGroup);
       formGroups.add(preferencesGroup);
+
       // fill groups with settings (as FormsFX fields)
-      for (Setting setting : groups.get(i).getSettings()) {
+      for (Setting setting : group.getSettings()) {
         formGroups.get(i).getElements().add(setting.getElement());
       }
     }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryView.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryView.java
@@ -6,6 +6,7 @@ import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.Group;
 import com.dlsc.preferencesfx.model.PreferencesFxModel;
 import com.dlsc.preferencesfx.model.Setting;
+import com.dlsc.preferencesfx.util.VisibilityProperty;
 import javafx.scene.layout.StackPane;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +55,12 @@ public class CategoryView extends StackPane implements View {
    */
   @Override
   public void initializeSelf() {
+    VisibilityProperty visibilityProperty = this.categoryModel.visibilityProperty();
 
+    if (visibilityProperty != null) {
+      this.visibleProperty().bind(visibilityProperty.get());
+      this.managedProperty().bind(visibilityProperty.get());
+    }
   }
 
   /**
@@ -77,6 +83,5 @@ public class CategoryView extends StackPane implements View {
    */
   @Override
   public void bindFieldsToModel() {
-
   }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/FilterableTreeItem.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/FilterableTreeItem.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.dlsc.preferencesfx.view;
 
+import java.util.HashMap;
+import java.util.Map;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -38,9 +40,11 @@ import java.util.function.Predicate;
  */
 public class FilterableTreeItem<T> extends CheckBoxTreeItem<T> {
 
-	private final ObservableList<TreeItem<T>> sourceList = FXCollections.observableArrayList();
-	private final FilteredList<TreeItem<T>> filteredList =new FilteredList<>(sourceList);
+	private final ObservableList<FilterableTreeItem<T>> sourceList = FXCollections.observableArrayList();
+	private final FilteredList<FilterableTreeItem<T>> filteredList =new FilteredList<>(sourceList);
 	private final ObjectProperty<TreeItemPredicate<T>> predicate = new SimpleObjectProperty<>();
+
+	private Map<FilterableTreeItem<T>, Integer> childItemIndexesMap = new HashMap<>();
 
 	/**
 	 * Creates a new {@link TreeItem} with sorted children.
@@ -50,8 +54,12 @@ public class FilterableTreeItem<T> extends CheckBoxTreeItem<T> {
 	public FilterableTreeItem(T value) {
 		super(value);
 
+		setupFilteredListPredicateBindings();
+	}
+
+	private void setupFilteredListPredicateBindings() {
 		filteredList.predicateProperty().bind(Bindings.createObjectBinding(() -> {
-			Predicate<TreeItem<T>> p =  child -> {
+			Predicate<FilterableTreeItem<T>> treeItemPredicate =  child -> {
 				// Set the predicate of child items to force filtering
 				if (child instanceof FilterableTreeItem) {
 					FilterableTreeItem<T> filterableChild = (FilterableTreeItem<T>) child;
@@ -71,16 +79,16 @@ public class FilterableTreeItem<T> extends CheckBoxTreeItem<T> {
 				// Otherwise ask the TreeItemPredicate
 				return predicate.get().test(this, child.getValue());
 			};
-			return p;
+			return treeItemPredicate;
 		}, predicate));
 
 		Bindings.bindContent(getChildren(), getBackingList());
 	}
-	
+
 	/**
 	 * @return the backing list
 	 */
-	protected ObservableList<TreeItem<T>> getBackingList() {
+	protected ObservableList<FilterableTreeItem<T>> getBackingList() {
 		return filteredList;
 	}
 
@@ -88,7 +96,7 @@ public class FilterableTreeItem<T> extends CheckBoxTreeItem<T> {
 	 * Returns the list of children that is backing the filtered list.
 	 * @return underlying list of children
 	 */
-	public ObservableList<TreeItem<T>> getInternalChildren() {
+	public ObservableList<FilterableTreeItem<T>> getInternalChildren() {
 		return sourceList;
 	}
 
@@ -102,15 +110,32 @@ public class FilterableTreeItem<T> extends CheckBoxTreeItem<T> {
 	/**
 	 * @return the predicate
 	 */
-    public final TreeItemPredicate<T> getPredicate() {
-        return predicate.get();
-    }
+	public final TreeItemPredicate<T> getPredicate() {
+			return predicate.get();
+	}
 
-    /**
-     * Set the predicate
-     * @param predicate the predicate
-     */
-    public final void setPredicate(TreeItemPredicate<T> predicate) {
-    	this.predicate.set(predicate);
-    }
+	/**
+	 * Set the predicate
+	 * @param predicate the predicate
+	 */
+	public final void setPredicate(TreeItemPredicate<T> predicate) {
+		this.predicate.set(predicate);
+	}
+
+	/**
+	 * Remove child item from {@link #sourceList} and save item position if visibility is false.
+	 * If visibility is true it restore (add item to {@link #sourceList}) to same position using index.
+	 *
+	 * @param childItem - child item object
+	 * @param visible		- visibility of this child item
+	 */
+	public void changeChildItemVisibility(FilterableTreeItem<T> childItem, boolean visible) {
+		if (visible) {
+			sourceList.add(childItemIndexesMap.get(childItem), childItem);
+		} else {
+			childItemIndexesMap.put(childItem, sourceList.indexOf(childItem));
+
+			sourceList.remove(childItem);
+		}
+	}
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/NavigationPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/NavigationPresenter.java
@@ -3,6 +3,9 @@ package com.dlsc.preferencesfx.view;
 import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.PreferencesFxModel;
 import com.dlsc.preferencesfx.util.SearchHandler;
+import java.util.stream.Collectors;
+import javafx.beans.property.StringProperty;
+import javafx.collections.ObservableList;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import org.slf4j.Logger;
@@ -107,18 +110,28 @@ public class NavigationPresenter implements Presenter {
 
   }
 
-  private void addRecursive(FilterableTreeItem<Category> treeItem, List<Category> categories) {
+  private void addRecursive(FilterableTreeItem<Category> parentTreeItem, List<Category> categories) {
     for (Category category : categories) {
-      FilterableTreeItem<Category> item = new FilterableTreeItem<>(category);
+      FilterableTreeItem<Category> treeItem = new FilterableTreeItem<>(category);
       if (category.isExpand()) {
-        item.setExpanded(true);
+        treeItem.setExpanded(true);
       }
+
       // If there are subcategories, add them recursively.
       if (category.getChildren() != null) {
-        addRecursive(item, category.getChildren());
+        addRecursive(treeItem, category.getChildren());
       }
-      treeItem.getInternalChildren().add(item);
-      categoryTreeItemMap.put(category, item);
+
+      parentTreeItem.getInternalChildren().add(treeItem);
+      categoryTreeItemMap.put(category, treeItem);
+
+      if (category.visibilityProperty() != null) {
+        category.visibilityProperty().get().addListener((observableValue, aBoolean, newValue) -> {
+          FilterableTreeItem<Category> childTreeItem = categoryTreeItemMap.get(category);
+
+          navigationView.rootItem.changeChildItemVisibility(childTreeItem, newValue);
+        });
+      }
     }
   }
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/NavigationView.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/NavigationView.java
@@ -92,6 +92,11 @@ public class NavigationView extends VBox implements View {
     model.searchTextProperty().bind(searchFld.textProperty());
   }
 
+  public void invalidate() {
+    // Workaround to trigger FilterableTreeItem filter functionality.
+    searchFld.textProperty().set(searchFld.textProperty().get());
+  }
+
   /**
    * Selects the given category TreeItem in the NavigationView.
    *


### PR DESCRIPTION
Added visibility functionality for Setting, Group, Category.

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [x] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [x] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [x] Tests for the changes are included.

## What is the current behavior?
No possibility to hide existing Setting, Group or Category 

## What is the new behavior?
This PR adds functionality for hide/show Setting, Group, Category objects

Fixes/Resolves/Closes #[Issue Number]

## Breaking Change: